### PR TITLE
Clarify vector index dimension best practice

### DIFF
--- a/modules/embeddings-vector-indexes/pages/query/search-prompt.adoc
+++ b/modules/embeddings-vector-indexes/pages/query/search-prompt.adoc
@@ -13,6 +13,7 @@ The vector index can then use the prompt embedding to retrieve the nodes whose e
 **Always use the same model to generate embeddings**: pick one and use it to generate embeddings for both the dataset and search prompts.
 Attempting to mix models with different vector sizes will result in an error.
 Models with the same vector size will work, but are unlikely to interact well with one another, as they most likely differ in the way they were trained.
+Create the vector index with an explicit `vector.dimensions` value matching that model, as shown in xref:setup/vector-index.adoc[Create vector index].
 
 
 == Similarity for embeddings generated with open source libraries

--- a/modules/embeddings-vector-indexes/pages/query/search-prompt.adoc
+++ b/modules/embeddings-vector-indexes/pages/query/search-prompt.adoc
@@ -13,7 +13,7 @@ The vector index can then use the prompt embedding to retrieve the nodes whose e
 **Always use the same model to generate embeddings**: pick one and use it to generate embeddings for both the dataset and search prompts.
 Attempting to mix models with different vector sizes will result in an error.
 Models with the same vector size will work, but are unlikely to interact well with one another, as they most likely differ in the way they were trained.
-Create the vector index with an explicit `vector.dimensions` value matching that model, as shown in xref:setup/vector-index.adoc[Create vector index].
+Provide a dimension when xref:setup/vector-index.adoc[creating a vector index], as it ensures that only vectors of that size are indexed and makes dimension mismatches fail explicitly at query time.
 
 
 == Similarity for embeddings generated with open source libraries

--- a/modules/embeddings-vector-indexes/pages/setup/vector-index.adoc
+++ b/modules/embeddings-vector-indexes/pages/setup/vector-index.adoc
@@ -2,7 +2,9 @@
 
 Vector indexes allow Neo4j to run similarity queries across the whole database.
 The example below shows how to create a vector index for movie embeddings, under the name of `moviePlots`.
-The examples explicitly set `vector.dimensions`, which is recommended because it ensures only embeddings of the expected size are indexed and makes dimension mismatches fail clearly at query time.
+
+[TIP]
+Provide a dimension when xref:setup/vector-index.adoc[creating a vector index] as shown in the examples below, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail explicitly at query time.
 
 [.tabbed-example]
 ====

--- a/modules/embeddings-vector-indexes/pages/setup/vector-index.adoc
+++ b/modules/embeddings-vector-indexes/pages/setup/vector-index.adoc
@@ -2,6 +2,7 @@
 
 Vector indexes allow Neo4j to run similarity queries across the whole database.
 The example below shows how to create a vector index for movie embeddings, under the name of `moviePlots`.
+The examples explicitly set `vector.dimensions`, which is recommended because it ensures only embeddings of the expected size are indexed and makes dimension mismatches fail clearly at query time.
 
 [.tabbed-example]
 ====
@@ -19,7 +20,7 @@ OPTIONS {indexConfig: {
 ----
 
 <1> For embeddings generated with the SentenceTransformers model `all-MiniLM-L6-v2`.
-A different model may require a different dimension.
+If you use a different model, update this value to match its embedding dimension.
 <2> The cosine similarity function is the most common choice. For more details and other options, see link:https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#similarity-functions[Vector indexes -> Cosine and Euclidean similarity functions].
 
 =====
@@ -46,7 +47,7 @@ OPTIONS {indexConfig: {
 ----
 
 <1> For embeddings generated with the OpenAI model `text-embedding-3-small`.
-A different model may require a different dimension.
+If you use a different model, update this value to match its embedding dimension.
 <2> The cosine similarity function is the most common choice. For more details and other options, see link:https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#similarity-functions[Vector indexes -> Cosine and Euclidean similarity functions].
 
 =====


### PR DESCRIPTION
## Summary
- recommend explicitly setting `vector.dimensions` in the vector index tutorial examples
- explain that the dimension should match the embedding model in use
- reinforce the same best practice in the search-prompt guidance

## Validation
- `git diff --check`
- local Antora build currently blocked by a missing `@neo4j-antora/roles-labels` module in this repo after upstream sync